### PR TITLE
[#11] Travel CRUD 기능 구현

### DIFF
--- a/src/main/java/com/example/travelog/domain/travel/controller/TravelController.java
+++ b/src/main/java/com/example/travelog/domain/travel/controller/TravelController.java
@@ -15,7 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "TRAVEL")
 public interface TravelController {
     @Operation(summary = "여행 생성")
-    public void createTravel(@Parameter(description = "여행명, 설명, 시작/종료 일자, 여행 장소 기입")
+    public ResponseEntity<?> createTravel(@Parameter(description = "여행명, 설명, 시작/종료 일자, 여행 장소 기입")
                              @Valid @RequestBody TravelCreateRequest request,
                              @AuthenticationPrincipal UserDetails userDetails);
 

--- a/src/main/java/com/example/travelog/domain/travel/controller/TravelController.java
+++ b/src/main/java/com/example/travelog/domain/travel/controller/TravelController.java
@@ -1,7 +1,32 @@
 package com.example.travelog.domain.travel.controller;
 
-import org.springframework.stereotype.Controller;
+import com.example.travelog.domain.travel.dto.request.TravelCreateRequest;
+import com.example.travelog.domain.travel.dto.request.TravelUpdateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
-@Controller
-public class TravelController {
+@Tag(name = "TRAVEL")
+public interface TravelController {
+    @Operation(summary = "여행 생성")
+    public void createTravel(@Parameter(description = "여행명, 설명, 시작/종료 일자, 여행 장소 기입")
+                             @Valid @RequestBody TravelCreateRequest request,
+                             @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(summary = "여행 섬네일 지정")
+    public String updateThumbnail(@PathVariable Long travelId,
+                                  @RequestPart("image") MultipartFile image,
+                                  @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(summary = "여행 수정")
+    public ResponseEntity<?> updateTravel(@Parameter(description = "여행명, 설명, 시작/종료 일자 기입")
+                                          @PathVariable Long travelId,
+                                          @RequestBody TravelUpdateRequest request,
+                                          @AuthenticationPrincipal UserDetails userDetails);
 }

--- a/src/main/java/com/example/travelog/domain/travel/controller/TravelController.java
+++ b/src/main/java/com/example/travelog/domain/travel/controller/TravelController.java
@@ -41,4 +41,7 @@ public interface TravelController {
     public ResponseEntity<TravelResponse> getTravel(@PathVariable Long travelId,
                                                     @AuthenticationPrincipal UserDetails userDetails);
 
+    @Operation(summary = "여행 삭제")
+    public ResponseEntity<?> deleteTravel(@PathVariable Long travelId,
+                                          @AuthenticationPrincipal UserDetails userDetails);
 }

--- a/src/main/java/com/example/travelog/domain/travel/controller/TravelController.java
+++ b/src/main/java/com/example/travelog/domain/travel/controller/TravelController.java
@@ -2,6 +2,8 @@ package com.example.travelog.domain.travel.controller;
 
 import com.example.travelog.domain.travel.dto.request.TravelCreateRequest;
 import com.example.travelog.domain.travel.dto.request.TravelUpdateRequest;
+import com.example.travelog.domain.travel.dto.response.TravelListResponse;
+import com.example.travelog.domain.travel.dto.response.TravelResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,6 +13,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Tag(name = "TRAVEL")
 public interface TravelController {
@@ -29,4 +33,12 @@ public interface TravelController {
                                           @PathVariable Long travelId,
                                           @RequestBody TravelUpdateRequest request,
                                           @AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(summary = "여행 목록 조회")
+    public ResponseEntity<List<TravelListResponse>> getTravelList(@AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(summary = "여행 상세 조회")
+    public ResponseEntity<TravelResponse> getTravel(@PathVariable Long travelId,
+                                                    @AuthenticationPrincipal UserDetails userDetails);
+
 }

--- a/src/main/java/com/example/travelog/domain/travel/controller/TravelControllerImpl.java
+++ b/src/main/java/com/example/travelog/domain/travel/controller/TravelControllerImpl.java
@@ -1,0 +1,45 @@
+package com.example.travelog.domain.travel.controller;
+
+import com.example.travelog.domain.s3.service.S3ImageService;
+import com.example.travelog.domain.travel.dto.request.TravelCreateRequest;
+import com.example.travelog.domain.travel.dto.request.TravelUpdateRequest;
+import com.example.travelog.domain.travel.service.TravelService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/travel")
+@RequiredArgsConstructor
+public class TravelControllerImpl implements TravelController {
+    private final TravelService travelService;
+    private final S3ImageService s3ImageService;
+
+    @PostMapping()
+    public void createTravel(@Valid @RequestBody TravelCreateRequest request,
+                             @AuthenticationPrincipal UserDetails userDetails) {
+        travelService.createTravel(request, userDetails.getUsername());
+
+    }
+
+    @PatchMapping("/{travelId}/thumbnail")
+    public String updateThumbnail(@PathVariable Long travelId,
+                                @RequestPart("image") MultipartFile image,
+                                @AuthenticationPrincipal UserDetails userDetails) {
+        String imageUrl = s3ImageService.upload(image);
+        travelService.updateTravelThumbnail(imageUrl, travelId, userDetails.getUsername());
+        return imageUrl;
+    }
+
+    @PatchMapping("/{travelId}")
+    public ResponseEntity<?> updateTravel(@PathVariable Long travelId,
+                                               @RequestBody TravelUpdateRequest request,
+                                               @AuthenticationPrincipal UserDetails userDetails) {
+        travelService.updateTravel(travelId, userDetails.getUsername(), request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/travelog/domain/travel/controller/TravelControllerImpl.java
+++ b/src/main/java/com/example/travelog/domain/travel/controller/TravelControllerImpl.java
@@ -61,4 +61,11 @@ public class TravelControllerImpl implements TravelController {
         TravelResponse response = travelService.getTravel(travelId, userDetails.getUsername());
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{travelId}")
+    public ResponseEntity<?> deleteTravel(@PathVariable Long travelId,
+                                               @AuthenticationPrincipal UserDetails userDetails) {
+        travelService.deleteTravel(travelId, userDetails.getUsername());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/travelog/domain/travel/controller/TravelControllerImpl.java
+++ b/src/main/java/com/example/travelog/domain/travel/controller/TravelControllerImpl.java
@@ -3,6 +3,7 @@ package com.example.travelog.domain.travel.controller;
 import com.example.travelog.domain.s3.service.S3ImageService;
 import com.example.travelog.domain.travel.dto.request.TravelCreateRequest;
 import com.example.travelog.domain.travel.dto.request.TravelUpdateRequest;
+import com.example.travelog.domain.travel.dto.response.TravelListResponse;
 import com.example.travelog.domain.travel.service.TravelService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/travel")
 @RequiredArgsConstructor
@@ -20,16 +23,16 @@ public class TravelControllerImpl implements TravelController {
     private final S3ImageService s3ImageService;
 
     @PostMapping()
-    public void createTravel(@Valid @RequestBody TravelCreateRequest request,
-                             @AuthenticationPrincipal UserDetails userDetails) {
+    public ResponseEntity<?> createTravel(@Valid @RequestBody TravelCreateRequest request,
+                                               @AuthenticationPrincipal UserDetails userDetails) {
         travelService.createTravel(request, userDetails.getUsername());
-
+        return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/{travelId}/thumbnail")
     public String updateThumbnail(@PathVariable Long travelId,
-                                @RequestPart("image") MultipartFile image,
-                                @AuthenticationPrincipal UserDetails userDetails) {
+                                  @RequestPart("image") MultipartFile image,
+                                  @AuthenticationPrincipal UserDetails userDetails) {
         String imageUrl = s3ImageService.upload(image);
         travelService.updateTravelThumbnail(imageUrl, travelId, userDetails.getUsername());
         return imageUrl;
@@ -37,9 +40,16 @@ public class TravelControllerImpl implements TravelController {
 
     @PatchMapping("/{travelId}")
     public ResponseEntity<?> updateTravel(@PathVariable Long travelId,
-                                               @RequestBody TravelUpdateRequest request,
-                                               @AuthenticationPrincipal UserDetails userDetails) {
+                                          @RequestBody TravelUpdateRequest request,
+                                          @AuthenticationPrincipal UserDetails userDetails) {
         travelService.updateTravel(travelId, userDetails.getUsername(), request);
         return ResponseEntity.ok().build();
+    }
+
+    // 여행 목록 조회
+    @GetMapping()
+    public ResponseEntity<List<TravelListResponse>> getTravelList(@AuthenticationPrincipal UserDetails userDetails) {
+        List<TravelListResponse> response = travelService.getTravelList(userDetails.getUsername());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/travelog/domain/travel/controller/TravelControllerImpl.java
+++ b/src/main/java/com/example/travelog/domain/travel/controller/TravelControllerImpl.java
@@ -4,6 +4,7 @@ import com.example.travelog.domain.s3.service.S3ImageService;
 import com.example.travelog.domain.travel.dto.request.TravelCreateRequest;
 import com.example.travelog.domain.travel.dto.request.TravelUpdateRequest;
 import com.example.travelog.domain.travel.dto.response.TravelListResponse;
+import com.example.travelog.domain.travel.dto.response.TravelResponse;
 import com.example.travelog.domain.travel.service.TravelService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,14 @@ public class TravelControllerImpl implements TravelController {
     @GetMapping()
     public ResponseEntity<List<TravelListResponse>> getTravelList(@AuthenticationPrincipal UserDetails userDetails) {
         List<TravelListResponse> response = travelService.getTravelList(userDetails.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    // 여행 상세 조회
+    @GetMapping("/{travelId}")
+    public ResponseEntity<TravelResponse> getTravel(@PathVariable Long travelId,
+                                                        @AuthenticationPrincipal UserDetails userDetails) {
+        TravelResponse response = travelService.getTravel(travelId, userDetails.getUsername());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/travelog/domain/travel/dto/request/TravelCreateRequest.java
+++ b/src/main/java/com/example/travelog/domain/travel/dto/request/TravelCreateRequest.java
@@ -1,6 +1,7 @@
 package com.example.travelog.domain.travel.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import java.time.LocalDateTime;
@@ -15,10 +16,10 @@ public record TravelCreateRequest(
         @NotBlank(message = "여행 위치는 필수 입력값입니다.")
         String location,
 
-        @NotBlank(message = "시작일은 필수 입력 값입니다.")
+        @NotNull(message = "시작일은 필수 입력 값입니다.")
         LocalDateTime startDate,
 
-        @NotBlank(message = "마감일은 필수 입력 값입니다.")
+        @NotNull(message = "마감일은 필수 입력 값입니다.")
         LocalDateTime endDate,
 
         double latitude,

--- a/src/main/java/com/example/travelog/domain/travel/dto/request/TravelCreateRequest.java
+++ b/src/main/java/com/example/travelog/domain/travel/dto/request/TravelCreateRequest.java
@@ -1,0 +1,26 @@
+package com.example.travelog.domain.travel.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record TravelCreateRequest(
+        @NotBlank(message = "여행명은 필수 입력값입니다.")
+        @Size(min = 1, max = 20, message = "여행명은 1~20자 지정 가능합니다.")
+        String title,
+
+        String description,
+
+        @NotBlank(message = "여행 위치는 필수 입력값입니다.")
+        String location,
+
+        @NotBlank(message = "시작일은 필수 입력 값입니다.")
+        LocalDateTime startDate,
+
+        @NotBlank(message = "마감일은 필수 입력 값입니다.")
+        LocalDateTime endDate,
+
+        double latitude,
+        double longitude
+) { }

--- a/src/main/java/com/example/travelog/domain/travel/dto/request/TravelUpdateRequest.java
+++ b/src/main/java/com/example/travelog/domain/travel/dto/request/TravelUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.example.travelog.domain.travel.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record TravelUpdateRequest(
+        @Size(min = 1, max = 20, message = "여행명은 1~20자 지정 가능합니다.")
+        String title,
+
+        String description,
+        LocalDateTime startDate,
+        LocalDateTime endDate
+) {
+}

--- a/src/main/java/com/example/travelog/domain/travel/dto/response/TravelListResponse.java
+++ b/src/main/java/com/example/travelog/domain/travel/dto/response/TravelListResponse.java
@@ -1,0 +1,7 @@
+package com.example.travelog.domain.travel.dto.response;
+
+public record TravelListResponse(
+        String title,
+        String location,
+        String thumbnailImage
+) { }

--- a/src/main/java/com/example/travelog/domain/travel/dto/response/TravelResponse.java
+++ b/src/main/java/com/example/travelog/domain/travel/dto/response/TravelResponse.java
@@ -1,0 +1,8 @@
+package com.example.travelog.domain.travel.dto.response;
+
+public record TravelResponse(
+        String title,
+        String description,
+        String location,
+        String thumbnailImage
+) { }

--- a/src/main/java/com/example/travelog/domain/travel/entity/Travel.java
+++ b/src/main/java/com/example/travelog/domain/travel/entity/Travel.java
@@ -3,10 +3,15 @@ package com.example.travelog.domain.travel.entity;
 import com.example.travelog.domain.user.entity.User;
 import com.example.travelog.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
 public class Travel extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,9 +23,28 @@ public class Travel extends BaseTimeEntity {
 
     private String title;
     private String description;
-    private String locaiton;
+    private String location;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
     private double latitude;
     private double longitude;
+    private String thumbnailUrl;
+
+    public void updateTravel(String title,
+                             String description,
+                             LocalDateTime startTime,
+                             LocalDateTime endTime) {
+        this.title = title;
+        this.description = description;
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
+    public void updateThumbnailImage(String imageUrl) {
+        this.thumbnailUrl = imageUrl;
+    }
+
+    public void deleteThumbnailImage() {
+        this.thumbnailUrl = null;
+    }
 }

--- a/src/main/java/com/example/travelog/domain/travel/entity/Travel.java
+++ b/src/main/java/com/example/travelog/domain/travel/entity/Travel.java
@@ -4,6 +4,8 @@ import com.example.travelog.domain.user.entity.User;
 import com.example.travelog.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +14,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Getter
 @Builder
+@SQLDelete(sql = "UPDATE travel SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
 public class Travel extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/travelog/domain/travel/repository/TravelRepository.java
+++ b/src/main/java/com/example/travelog/domain/travel/repository/TravelRepository.java
@@ -1,10 +1,13 @@
 package com.example.travelog.domain.travel.repository;
 
 import com.example.travelog.domain.travel.entity.Travel;
+import com.example.travelog.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TravelRepository extends JpaRepository <Travel, Long> {
-
+    List<Travel> findAllByUser(User user);
 }

--- a/src/main/java/com/example/travelog/domain/travel/repository/TravelRepository.java
+++ b/src/main/java/com/example/travelog/domain/travel/repository/TravelRepository.java
@@ -1,0 +1,10 @@
+package com.example.travelog.domain.travel.repository;
+
+import com.example.travelog.domain.travel.entity.Travel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TravelRepository extends JpaRepository <Travel, Long> {
+
+}

--- a/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
+++ b/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
@@ -2,6 +2,7 @@ package com.example.travelog.domain.travel.service;
 
 import com.example.travelog.domain.travel.dto.request.TravelCreateRequest;
 import com.example.travelog.domain.travel.dto.request.TravelUpdateRequest;
+import com.example.travelog.domain.travel.dto.response.TravelListResponse;
 import com.example.travelog.domain.travel.entity.Travel;
 import com.example.travelog.domain.travel.repository.TravelRepository;
 import com.example.travelog.domain.user.entity.User;
@@ -11,6 +12,8 @@ import com.example.travelog.global.exception.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -69,5 +72,20 @@ public class TravelService {
                 request.startDate(),
                 request.endDate()
         );
+    }
+
+    public List<TravelListResponse> getTravelList(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_USER));
+
+        List<Travel> travelList = travelRepository.findAllByUser(user);
+
+        return travelList.stream()
+                .map(travel -> new TravelListResponse(
+                        travel.getTitle(),
+                        travel.getLocation(),
+                        travel.getThumbnailUrl()
+                )).toList();
+
     }
 }

--- a/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
+++ b/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
@@ -107,4 +107,18 @@ public class TravelService {
                 travel.getThumbnailUrl()
         );
     }
+
+    public void deleteTravel(Long travelId, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_USER));
+
+        Travel travel = travelRepository.findById(travelId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_TRAVEL));
+
+        if (!travel.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN_USER);
+        }
+
+        travelRepository.delete(travel);
+    }
 }

--- a/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
+++ b/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class TravelService {
-}
     private final UserRepository userRepository;
     private final TravelRepository travelRepository;
 
@@ -36,3 +35,14 @@ public class TravelService {
 
         travelRepository.save(travel);
     }
+
+    public void updateTravelThumbnail(String imageUrl, Long travelId, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_USER));
+
+        Travel travel = travelRepository.findById(travelId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_TRAVEL));
+
+        if (!travel.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN_USER);
+        }

--- a/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
+++ b/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
@@ -1,7 +1,38 @@
 package com.example.travelog.domain.travel.service;
 
+import com.example.travelog.domain.travel.dto.request.TravelCreateRequest;
+import com.example.travelog.domain.travel.dto.request.TravelUpdateRequest;
+import com.example.travelog.domain.travel.entity.Travel;
+import com.example.travelog.domain.travel.repository.TravelRepository;
+import com.example.travelog.domain.user.entity.User;
+import com.example.travelog.domain.user.repository.UserRepository;
+import com.example.travelog.global.exception.CustomException;
+import com.example.travelog.global.exception.ErrorCode;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class TravelService {
 }
+    private final UserRepository userRepository;
+    private final TravelRepository travelRepository;
+
+    public void createTravel(TravelCreateRequest request, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_USER));
+
+        Travel travel = Travel.builder()
+                .user(user)
+                .title(request.title())
+                .description(request.description())
+                .location(request.location())
+                .startTime(request.startDate())
+                .endTime(request.endDate())
+                .latitude(request.latitude())
+                .longitude(request.longitude())
+                .build();
+
+        travelRepository.save(travel);
+    }

--- a/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
+++ b/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
@@ -3,6 +3,7 @@ package com.example.travelog.domain.travel.service;
 import com.example.travelog.domain.travel.dto.request.TravelCreateRequest;
 import com.example.travelog.domain.travel.dto.request.TravelUpdateRequest;
 import com.example.travelog.domain.travel.dto.response.TravelListResponse;
+import com.example.travelog.domain.travel.dto.response.TravelResponse;
 import com.example.travelog.domain.travel.entity.Travel;
 import com.example.travelog.domain.travel.repository.TravelRepository;
 import com.example.travelog.domain.user.entity.User;
@@ -86,6 +87,24 @@ public class TravelService {
                         travel.getLocation(),
                         travel.getThumbnailUrl()
                 )).toList();
+    }
 
+    public TravelResponse getTravel(Long travelId, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_USER));
+
+        Travel travel = travelRepository.findById(travelId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_TRAVEL));
+
+        if (!travel.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN_USER);
+        }
+
+        return new TravelResponse(
+                travel.getTitle(),
+                travel.getDescription(),
+                travel.getLocation(),
+                travel.getThumbnailUrl()
+        );
     }
 }

--- a/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
+++ b/src/main/java/com/example/travelog/domain/travel/service/TravelService.java
@@ -46,3 +46,28 @@ public class TravelService {
         if (!travel.getUser().getId().equals(user.getId())) {
             throw new CustomException(ErrorCode.FORBIDDEN_USER);
         }
+
+        if (imageUrl != null) travel.updateThumbnailImage(imageUrl);
+        travelRepository.save(travel);
+    }
+
+    @Transactional
+    public void updateTravel(Long travelId, String email, TravelUpdateRequest request) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_USER));
+
+        Travel travel = travelRepository.findById(travelId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUNT_TRAVEL));
+
+        if (!travel.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN_USER);
+        }
+
+        travel.updateTravel(
+                request.title(),
+                request.description(),
+                request.startDate(),
+                request.endDate()
+        );
+    }
+}

--- a/src/main/java/com/example/travelog/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/travelog/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     ALREADY_EXIST_NICKNAME(HttpStatus.CONFLICT, "해당 닉네임의 유저가 이미 존재합니다."),
     NOT_FOUNT_USER(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    FORBIDDEN_USER(HttpStatus.FORBIDDEN, "해당 유저에게 권한이 없습니다."),
 
     // S3
     EMPTY_FILE(HttpStatus.BAD_REQUEST, "업로드할 파일이 비어 있습니다."),
@@ -17,7 +18,11 @@ public enum ErrorCode {
     NO_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "파일 확장자가 없습니다."),
     IO_EXCEPTION_ON_IMAGE_UPLOAD(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드 중 오류가 발생했습니다."),
     IO_EXCEPTION_ON_IMAGE_DELETE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제 중 오류가 발생했습니다."),
-    PUT_OBJECT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "S3에 이미지 업로드 실패했습니다.");
+    PUT_OBJECT_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "S3에 이미지 업로드 실패했습니다."),
+
+    // Travel
+    NOT_FOUNT_TRAVEL(HttpStatus.NOT_FOUND, "해당 여행을 찾을 수 없습니다.");
+
 
     private final HttpStatus errorCode;
     private final String errorMessage;


### PR DESCRIPTION
## Summary

>- #11 
close #11 

## Tasks
- 여행 생성
  - [x] 여행명, 여행 날짜 지정
  - [x] 여행 위치 지정 (위도, 경도)
  - [x] 여행 대문 사진 지정
- 여행 수정
  - [x] 여행명, 여행 날짜, 여행 위치 수정
  - [x] 여행 대문 사진 수정
  - [x] 본인 여부 인증 필요
- 여행 목록 조회
  - [x] 여행명, 여행 날짜, 여행 위치, 여행 대문 사진 반환
- 여행 조회
  - [x] 여행명, 여행 소개, 여행 날짜, 여행 위치, 여행 대문 사진 반환
- 여행 삭제
  - [x] 본인 여부 인증 필요
  - [x] 논리 삭제

## To Reviewer
- 섬네일 사진 지정의 경우 지금 지정/수정 api가 하나로 쓰는 상태
  후에 필요하다면 분리할 생각
- 여행 섬네일, 프로필 사진 등록 api 외에도 사진 삭제 api 필요해보임
  추후에 큰 작업들 마친 뒤에 개발하는 걸로 !
